### PR TITLE
Add getOutput() to retrieve output of last compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ Assuming you have managed your own autoloader, set your own includes or are usin
 	$compiler->setTargetBaseDir('path/to/javascript-files/');
 	$compiler->setSourceFiles(array('one.js', 'two.js', 'three.js'));
 	$compiler->addSourceFile('four');
-	$compiler->compile();
+	$result = $compiler->compile();
+	if ($result !== 0) {
+		echo $compiler->getOutput();
+	}
 
 The `compile()` method uses a system call to execute the Jar-file. By default, the resulting file is called `compiled.js`. You can change this by calling this before you compile:
 

--- a/src/ClosureCompiler/ClosureCompiler.php
+++ b/src/ClosureCompiler/ClosureCompiler.php
@@ -40,6 +40,11 @@ class ClosureCompiler
     protected $java;
     protected $compilerJar = 'compiler-latest/compiler.jar';
 
+    /**
+     * @var string Output from last compile
+     */
+    protected $output = '';
+
     protected $config = array(
         'sourceBaseDir' => '',
         'targetBaseDir' => '',
@@ -224,7 +229,18 @@ class ClosureCompiler
         $return = '';
         $output = array();
         exec($command, $output, $return);
+        $this->output = implode("\n", $output);
         return $return;
+    }
+
+    /**
+     * Gets output of last compile
+     *
+     * @return string
+     */
+    public function getOutput()
+    {
+        return $this->output;
     }
 }
 

--- a/tests/closureCompilerTest.php
+++ b/tests/closureCompilerTest.php
@@ -248,6 +248,7 @@ class closureCompilerTest extends PHPUnit_Framework_TestCase
         $this->object->setTargetFile('test.js');
         $result = $this->object->compile();
         $this->assertEquals(1, $result);
+        $this->assertStringStartsWith('ERROR - Cannot read: vfs:/tmp/test.js', $this->object->getOutput());
     }
 
     /**
@@ -263,6 +264,7 @@ class closureCompilerTest extends PHPUnit_Framework_TestCase
         $this->object->setSourceFiles(array('test.js'));
         $result = $this->object->compile();
         $this->assertEquals(1, $result);
+        $this->assertStringStartsWith('ERROR - Cannot read: vfs:/tmp/test.js', $this->object->getOutput());
     }
 
     /**
@@ -279,6 +281,7 @@ class closureCompilerTest extends PHPUnit_Framework_TestCase
         $this->object->setSourceFiles(array('test.js'));
         $this->object->setTargetBaseDir($dir);
         $result = $this->object->compile();
+        $this->assertStringStartsWith('java.io.FileNotFoundException: vfs:/tmp/compiled.js (No such file or directory)', $this->object->getOutput());
         $result = $this->object->getConfig();
         $this->assertEquals('vfs://tmp/compiled.js', $result['targetFileName']);
     }


### PR DESCRIPTION
Created a simple way to get the output of the compile() output.  Useful if there is a failure.